### PR TITLE
Insert first patients (View Patient Demographics)

### DIFF
--- a/src/main/java/com/abernathy/mediscreen/controllers/PatientController.java
+++ b/src/main/java/com/abernathy/mediscreen/controllers/PatientController.java
@@ -1,0 +1,38 @@
+package com.abernathy.mediscreen.controllers;
+
+import com.abernathy.mediscreen.domain.Patient;
+import com.abernathy.mediscreen.service.PatientService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.validation.Valid;
+
+@Controller
+public class PatientController {
+
+    @Autowired
+    PatientService patientService;
+
+    private static final Logger logger = LogManager.getLogger("PatientController");
+
+    @GetMapping("/patient/add")
+    public String addRuleForm(Patient patient) {
+        logger.info("User connected to /patient/add endpoint");
+        return patientService.addForm(patient);
+    }
+
+    @PostMapping("/patient/validate")
+    public String validate(@Valid Patient patient, BindingResult result, Model model) {
+        logger.info("User connected to /patient/validate endpoint");
+        return patientService.validate(patient,result,model);
+    }
+
+}

--- a/src/main/java/com/abernathy/mediscreen/service/BaseService.java
+++ b/src/main/java/com/abernathy/mediscreen/service/BaseService.java
@@ -1,0 +1,67 @@
+package com.abernathy.mediscreen.service;
+
+import com.abernathy.mediscreen.domain.DomainElement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+
+import javax.validation.Valid;
+
+public abstract class BaseService <E extends DomainElement> {
+
+    private JpaRepository<E, Integer> repository;
+
+    public BaseService(JpaRepository<E, Integer> repository) {
+        this.repository = repository;
+    }
+
+
+    private String getType() {
+        String className = getClass().getSimpleName().replace("Service","");
+        return className.substring(0,1).toLowerCase() + className.substring(1);
+    }
+
+    /**
+     * Method to populate Model for frontend
+     * Obtains all elements of this type from repository and adds to model
+     * Then returns redirect to list url
+     *
+     * @param model Model object to hold data loaded from repo
+     * @return redirect url String
+     */
+    public String home(Model model)
+    {
+        model.addAttribute(getType() + "s", repository.findAll());
+        return getType() + "/list";
+    }
+
+    /**
+     * Method to get redirect for form to add a new element
+     *
+     * @param e DomainElement object of type to be added
+     * @return url String
+     */
+    public String addForm(DomainElement e) {
+        return getType() + "/add";
+    }
+
+    /**
+     * Method to validate provided DomainElement
+     * Adds DomainElement to repository if valid & updates model
+     * Returns to form if any errors found
+     *
+     * @param e DomainElement object to be added
+     * @param result BindingResult for validation
+     * @param model Model object
+     * @return url String
+     */
+    public String validate(@Valid E e, BindingResult result, Model model) {
+        if (!result.hasErrors()){
+            repository.save(e);
+            model.addAttribute(getType() + "s", repository.findAll());
+            return getType() + "/add";
+        }
+        return getType() + "/add";
+    }
+
+}

--- a/src/main/java/com/abernathy/mediscreen/service/PatientService.java
+++ b/src/main/java/com/abernathy/mediscreen/service/PatientService.java
@@ -1,0 +1,14 @@
+package com.abernathy.mediscreen.service;
+
+import com.abernathy.mediscreen.domain.Patient;
+import com.abernathy.mediscreen.repository.PatientRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PatientService extends BaseService<Patient> {
+
+        public PatientService(PatientRepository patientRepository) {
+            super (patientRepository);
+        }
+
+}

--- a/src/main/resources/templates/patient/add.html
+++ b/src/main/resources/templates/patient/add.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" 
+	  xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="utf-8"/>
+<title>Home</title>
+<link rel="stylesheet" href="../../css/bootstrap.min.css" >
+</head>
+<body>
+<div class="container">
+
+	<div class="row">
+		<h2>Add New Bid</h2>
+	</div>
+
+	<div class="row">
+		<form action="#" th:action="@{/patient/validate}" th:object="${patient}" method="post" class="form-horizontal" style="width: 100%">
+			<div class="form-group">
+				<label for="familyName" class="col-sm-2 control-label">Family Name</label>
+				<div class="col-sm-10">
+					<input type="text" th:field="*{familyName}" id="familyName" placeholder="Family Name" class="col-4">
+					<p class="text-danger" th:if="${#fields.hasErrors('familyName')}" th:errors="*{familyName}"></p>
+				</div>
+			</div>
+			<div class="form-group">
+				<label for="givenName" class="col-sm-2 control-label">Given Name</label>
+				<div class="col-sm-10">
+					<input type="text" th:field="*{givenName}" id="givenName" placeholder="Given Name" class="col-4">
+					<p class="text-danger" th:if="${#fields.hasErrors('givenName')}" th:errors="*{givenName}"></p>
+				</div>
+			</div>
+			<div class="form-group">
+				<label for="dob" class="col-sm-2 control-label">Date of Birth</label>
+				<div class="col-sm-10">
+					<input type="date" th:field="*{dob}" id="dob" placeholder="dob" class="col-4">
+					<p class="text-danger" th:if="${#fields.hasErrors('dob')}" th:errors="*{dob}"></p>
+				</div>
+			</div>
+			<div class="form-group">
+				<label for="sex" class="col-sm-2 control-label">Sex</label>
+				<div class="col-sm-10">
+					<input type="text" th:field="*{sex}" id="sex" placeholder="Sex" class="col-4">
+					<p class="text-danger" th:if="${#fields.hasErrors('sex')}" th:errors="*{sex}"></p>
+				</div>
+			</div>
+			<div class="form-group">
+				<label for="address" class="col-sm-2 control-label">Address</label>
+				<div class="col-sm-10">
+					<input type="text" th:field="*{address}" id="address" placeholder="Address" class="col-4">
+					<p class="text-danger" th:if="${#fields.hasErrors('address')}" th:errors="*{address}"></p>
+				</div>
+			</div>
+			<div class="form-group">
+				<label for="phone" class="col-sm-2 control-label">Phone</label>
+				<div class="col-sm-10">
+					<input type="text" th:field="*{phone}" id="phone" placeholder="Phone" class="col-4">
+					<p class="text-danger" th:if="${#fields.hasErrors('phone')}" th:errors="*{phone}"></p>
+				</div>
+			</div>
+
+
+			<div class="form-group">
+				<div class="col-sm-12">
+					<input class="btn btn-primary btn-sm" type="submit" value="Add patient">
+				</div>
+			</div>
+
+		</form>
+	</div>
+
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/patient/add.html
+++ b/src/main/resources/templates/patient/add.html
@@ -3,14 +3,13 @@
 	  xmlns:th="http://www.thymeleaf.org">
 <head>
 <meta charset="utf-8"/>
-<title>Home</title>
-<link rel="stylesheet" href="../../css/bootstrap.min.css" >
+<title>Add Patient</title>
 </head>
 <body>
 <div class="container">
 
 	<div class="row">
-		<h2>Add New Bid</h2>
+		<h2>Add New Patient</h2>
 	</div>
 
 	<div class="row">


### PR DESCRIPTION
- added BaseService & extended with PatientService, includes methods to add/validate patients
- added PatientController with endpoints for adding/validating new patients
- added patients/add.html template, basic UI for adding new patients

Completed steps to allow new Patients to be added to the MySQL database, using a basic Thymeleaf web UI.
PatientService extends a generic BaseService to allow for easier expansion if required.
Currently while this UI can be used to successfully add new Patients to the system via the endpoint /patient/add, there is no functionality to view or access these yet to give confirmation to the user, however they are correctly stored in the database.

https://trello.com/c/v4voHBKp/1-view-patient-demographics