### PR TITLE
Validate retrieval (View Patient Demographics)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
 
@@ -48,6 +53,33 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<!--<version>5.2.0</version>-->
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.springtestdbunit</groupId>
+			<artifactId>spring-test-dbunit</artifactId>
+			<version>1.3.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.dbunit</groupId>
+			<artifactId>dbunit</artifactId>
+			<version>2.6.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>jakarta.validation</groupId>
 			<artifactId>jakarta.validation-api</artifactId>

--- a/src/main/java/com/abernathy/mediscreen/domain/Patient.java
+++ b/src/main/java/com/abernathy/mediscreen/domain/Patient.java
@@ -20,7 +20,7 @@ public class Patient implements DomainElement {
     private String givenName;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date dob;
-    @Size(min=1, max=1, message="Sex must be entered as either 'M' or 'F'")
+    @Pattern(regexp = "^[FM]|[fm]$", message="Sex must be entered as either 'M' or 'F'")
     private String sex;
     @NotEmpty(message = "Address is mandatory")
     private String address;

--- a/src/main/java/com/abernathy/mediscreen/domain/Patient.java
+++ b/src/main/java/com/abernathy/mediscreen/domain/Patient.java
@@ -3,6 +3,9 @@ package com.abernathy.mediscreen.domain;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import java.util.Date;
 
 @Entity
@@ -11,12 +14,18 @@ public class Patient implements DomainElement {
     @Id
     @GeneratedValue(strategy= GenerationType.AUTO)
     private int patientId;
+    @NotEmpty(message = "Family Name is mandatory")
     private String familyName;
+    @NotEmpty(message = "Given Name is mandatory")
     private String givenName;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date dob;
+    @Size(min=1, max=1, message="Sex must be entered as either 'M' or 'F'")
     private String sex;
+    @NotEmpty(message = "Address is mandatory")
     private String address;
+    @Pattern(regexp = "^\\d\\d\\d-{1}\\d\\d\\d-{1}\\d\\d\\d\\d$",
+    message="Phone must be entered in the format 123-456-7890")
     private String phone;
 
     public int getPatientId() {

--- a/src/main/java/com/abernathy/mediscreen/service/BaseService.java
+++ b/src/main/java/com/abernathy/mediscreen/service/BaseService.java
@@ -62,7 +62,7 @@ public abstract class BaseService <E extends DomainElement> {
         if (!result.hasErrors()){
             repository.save(e);
             model.addAttribute(getType() + "s", repository.findAll());
-            return getType() + "/add";
+            return "redirect:/" + getType() + "/list";
         }
         return getType() + "/add";
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,6 @@
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
 spring.datasource.url=jdbc:mysql://localhost:3310/mediscreen
 spring.datasource.username=root
 spring.datasource.password=password

--- a/src/test/java/com/abernathy/mediscreen/jpa/PatientJPATests.java
+++ b/src/test/java/com/abernathy/mediscreen/jpa/PatientJPATests.java
@@ -1,0 +1,80 @@
+package com.abernathy.mediscreen.jpa;
+
+import com.abernathy.mediscreen.domain.Patient;
+import com.abernathy.mediscreen.repository.PatientRepository;
+import com.github.springtestdbunit.TransactionDbUnitTestExecutionListener;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.persistence.EntityManager;
+import javax.sql.DataSource;
+import java.util.Date;
+import java.util.List;
+
+@DataJpaTest
+@TestExecutionListeners({
+        DependencyInjectionTestExecutionListener.class,
+        TransactionDbUnitTestExecutionListener.class
+})
+public class PatientJPATests {
+
+    @Autowired
+    DataSource dataSource;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    PatientRepository patientRepository;
+
+    @Test
+    void testCreatePatientEntity() {
+        int startingDbSize = patientRepository.findAll().size();
+
+        Patient testPatient = new Patient();
+        testPatient.setFamilyName("TestFam");
+        testPatient.setGivenName("TestGiven");
+        testPatient.setAddress("TestAddress");
+        testPatient.setDob(new Date());
+        testPatient.setPhone("100-222-3333");
+        patientRepository.save(testPatient);
+
+        int endingDbSize = patientRepository.findAll().size();
+
+        assertEquals(endingDbSize, startingDbSize + 1);
+    }
+
+    @Test
+    void testGetPatientEntity() {
+        Patient testPatientOne = new Patient();
+        testPatientOne.setFamilyName("FamilyNameOne");
+        testPatientOne.setGivenName("GivenNameOne");
+        testPatientOne.setAddress("AddressOne");
+        testPatientOne.setDob(new Date());
+        testPatientOne.setPhone("111-222-3333");
+        patientRepository.save(testPatientOne);
+
+        Patient testPatientTwo = new Patient();
+        testPatientTwo.setFamilyName("FamilyNameTwo");
+        testPatientTwo.setGivenName("GivenNameTwo");
+        testPatientTwo.setAddress("AddressTwo");
+        testPatientTwo.setDob(new Date());
+        testPatientTwo.setPhone("111-222-3333");
+        patientRepository.save(testPatientTwo);
+
+        assertNotNull(patientRepository.findById(1));
+        assertNotNull(patientRepository.findById(2));
+        Patient loadPatientOne = patientRepository.findById(1).get();
+        Patient loadPatientTwo = patientRepository.findById(2).get();
+        assertEquals(testPatientOne.getFamilyName(), loadPatientOne.getFamilyName());
+        assertEquals(testPatientTwo.getFamilyName(), loadPatientTwo.getFamilyName());
+    }
+
+}


### PR DESCRIPTION
- added PatientJPATests to use @DataJpaTest to test&validate adding/retrieving data
- updated Patient, BaseService, & Pom to enable field validation for add form

The main focus here is the DataJPATests to validate retrieval and allow testing to be performed. The opportunity was taken at this time to also add field validation to ensure that data added to the system was valid.

https://trello.com/c/v4voHBKp/1-view-patient-demographics