### PR TITLE
Validate service (View Patient Demographics)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,23 @@ services:
         networks:
             - system
             - admin
+    patientsdb-test:
+        image: mysql
+        command: --default-authentication-plugin=mysql_native_password
+        restart: always
+        environment:
+            MYSQL_ROOT_PASSWORD: 'password'
+            MYSQL_DATABASE: 'mediscreen-test'
+        ports:
+            - "3311:3306"
+        expose:
+            - "3311"
+        volumes:
+            - mediscreen-db:/var/lib/mediscreen-test
+        container_name: patients_db-test
+        networks:
+            - system
+            - admin
     adminer:
         image: adminer
         restart: always

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,13 @@
 			<artifactId>jakarta.validation-api</artifactId>
 			<version>2.0.2</version>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/abernathy/mediscreen/controllers/PatientController.java
+++ b/src/main/java/com/abernathy/mediscreen/controllers/PatientController.java
@@ -9,10 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -24,6 +21,7 @@ public class PatientController {
 
     private static final Logger logger = LogManager.getLogger("PatientController");
 
+    //Endpoints for serving front end
     @RequestMapping("/patient/list")
     public String home(Model model)
     {
@@ -43,16 +41,24 @@ public class PatientController {
         return patientService.validate(patient,result,model);
     }
 
-    @GetMapping("/patient/get/{id}")
-    public ResponseEntity<String> getPatient(@PathVariable("id") Integer id, Model model) {
-        logger.info("User connected to /patient/get endpoint with id " + id);
-        return patientService.get(id, model);
-    }
-
     @GetMapping("/patient/view/{id}")
     public String viewPatient(@PathVariable("id") Integer id, Model model) {
         logger.info("User connected to /patient/view endpoint with id " + id);
         return patientService.view(id, model);
+    }
+
+    //Endpoints for serving REST API
+
+    @PostMapping("/patient/api/add")
+    public ResponseEntity<String> addPatientApi(@Valid @RequestBody Patient patient, BindingResult result, Model model) {
+        logger.info("User connected to /patient/add endpoint");
+        return patientService.addPatient(patient, result, model);
+    }
+
+    @GetMapping("/patient/api/get/{id}")
+    public ResponseEntity<String> getPatientApi(@PathVariable("id") Integer id, Model model) {
+        logger.info("User connected to /patient/get endpoint with id " + id);
+        return patientService.get(id, model);
     }
 
 }

--- a/src/main/java/com/abernathy/mediscreen/service/BaseService.java
+++ b/src/main/java/com/abernathy/mediscreen/service/BaseService.java
@@ -24,6 +24,8 @@ public abstract class BaseService <E extends DomainElement> {
         return className.substring(0,1).toLowerCase() + className.substring(1);
     }
 
+    //Methods to serve Front End requests
+
     /**
      * Method to populate Model for frontend
      * Obtains all elements of this type from repository and adds to model
@@ -67,6 +69,14 @@ public abstract class BaseService <E extends DomainElement> {
         return getType() + "/add";
     }
 
+    public String view(Integer id, Model model) {
+        E e = repository.findById(id).orElseThrow(() -> new IllegalArgumentException("Invalid " + getType() + " Id:" + id));
+        model.addAttribute("currentPatient", e);
+        return getType() + "/view";
+    }
+
+    //Methods to serve REST API requests
+
     public ResponseEntity<String> get(Integer id, Model model) {
         try {
             E e = repository.findById(id).orElseThrow(() -> new IllegalArgumentException("Invalid " + getType() + " Id:" + id));
@@ -77,10 +87,13 @@ public abstract class BaseService <E extends DomainElement> {
         }
     }
 
-    public String view(Integer id, Model model) {
-        E e = repository.findById(id).orElseThrow(() -> new IllegalArgumentException("Invalid " + getType() + " Id:" + id));
-        model.addAttribute("currentPatient", e);
-        return getType() + "/view";
+    public ResponseEntity<String> addPatient(E e, BindingResult result, Model model) {
+        if (!result.hasErrors()){
+            repository.save(e);
+            model.addAttribute(getType() + "s", repository.findAll());
+            return new ResponseEntity<String>(e.toString(), new HttpHeaders(), HttpStatus.CREATED);
+        }
+        return new ResponseEntity<String>("Failed to add new entry.", new HttpHeaders(), HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,7 @@
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+spring.datasource.url=jdbc:mysql://localhost:3311/mediscreen-test
+spring.datasource.username=root
+spring.datasource.password=password
+spring.datasource.initialization-mode=always

--- a/src/test/java/com/abernathy/mediscreen/api/PatientControllerAPITests.java
+++ b/src/test/java/com/abernathy/mediscreen/api/PatientControllerAPITests.java
@@ -1,0 +1,142 @@
+package com.abernathy.mediscreen.api;
+
+import com.abernathy.mediscreen.domain.Patient;
+import com.abernathy.mediscreen.repository.PatientRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@WebAppConfiguration
+@AutoConfigureMockMvc
+@TestPropertySource(
+        locations = "classpath:application-test.properties")
+public class PatientControllerAPITests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @MockBean
+    private static PatientRepository patientRepository;
+
+    @Test
+    public void patientControllerAPIAddsEntry() throws Exception {
+
+        Patient patient = new Patient();
+        patient.setFamilyName("testFamilyName");
+        patient.setGivenName("testFirstName");
+        patient.setDob(new Date());
+        patient.setSex("F");
+        patient.setAddress("testAddress");
+        patient.setPhone("111-222-3333");
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        ObjectWriter ow = mapper.writer().withDefaultPrettyPrinter();
+        String requestJson=ow.writeValueAsString(patient);
+
+        MvcResult mvcResult = mockMvc.perform(
+                post("/patient/api/add")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                        .accept(MediaType.ALL)).andReturn();
+
+        //Verify entry is added to DB, and we get created response (201)
+        assertTrue(mvcResult.getResponse().getStatus() == 201);
+        Mockito.verify(patientRepository, Mockito.times(1)).save(any(Patient.class));
+    }
+
+    @Test
+    public void patientControllerAPIWillNotAddInvalidEntry() throws Exception {
+
+        Patient patient = new Patient();
+        patient.setFamilyName("testFamilyName");
+        patient.setGivenName("testFirstName");
+        patient.setDob(new Date());
+        patient.setSex("abcd");
+        patient.setAddress("testAddress");
+        patient.setPhone("phone");
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        ObjectWriter ow = mapper.writer().withDefaultPrettyPrinter();
+        String requestJson=ow.writeValueAsString(patient);
+
+        MvcResult mvcResult = mockMvc.perform(
+                post("/patient/api/add")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                        .accept(MediaType.ALL)).andReturn();
+
+        //Verify no entry is added to DB, and we get Bad Request response (400)
+        assertTrue(mvcResult.getResponse().getStatus() == 400);
+        Mockito.verify(patientRepository, Mockito.times(0)).save(any(Patient.class));
+    }
+
+    @Test
+    public void patientControllerAPIGetsEntry() throws Exception {
+
+        //Create mock patient
+        Patient patient = new Patient();
+        patient.setFamilyName("testFamilyName");
+        patient.setGivenName("testFirstName");
+        patient.setDob(new Date());
+        patient.setSex("F");
+        patient.setAddress("testAddress");
+        patient.setPhone("111-222-3333");
+
+        //If our service works and asks the repo for patient with id 1, return our mock patient
+        when(patientRepository.findById(1)).thenReturn(java.util.Optional.of(patient));
+
+        //Attempt to retrieve patient
+        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders.get("/patient/api/get/1")
+                .accept(MediaType.APPLICATION_JSON_VALUE)).andReturn();
+
+        //Verify entry is retrieved from DB, and we get success response (200)
+        assertTrue(mvcResult.getResponse().getStatus() == 200);
+        Mockito.verify(patientRepository, Mockito.times(1)).findById(1);
+
+    }
+
+    @Test
+    public void patientControllerAPIDoesNotGetInvalidEntry() throws Exception {
+
+        //Attempt to retrieve patient
+        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders.get("/patient/api/get/1")
+                .accept(MediaType.APPLICATION_JSON_VALUE)).andReturn();
+
+        //Verify retrieval is attempted from DB, and we get Not Found response (404)
+        assertTrue(mvcResult.getResponse().getStatus() == 404);
+        Mockito.verify(patientRepository, Mockito.times(1)).findById(1);
+
+    }
+
+}

--- a/src/test/java/com/abernathy/mediscreen/api/PatientControllerUITests.java
+++ b/src/test/java/com/abernathy/mediscreen/api/PatientControllerUITests.java
@@ -1,0 +1,96 @@
+package com.abernathy.mediscreen.api;
+
+
+import com.abernathy.mediscreen.domain.Patient;
+import com.abernathy.mediscreen.repository.PatientRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@WebAppConfiguration
+@AutoConfigureMockMvc
+@TestPropertySource(
+        locations = "classpath:application-test.properties")
+public class PatientControllerUITests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @MockBean
+    private static PatientRepository patientRepository;
+
+    @Test
+    public void patientControllerGetListEndpoint() throws Exception {
+
+        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders.get("/patient/list").accept(MediaType.APPLICATION_JSON_VALUE)).andReturn();
+
+        assertTrue(mvcResult.getResponse().getStatus() == 200);
+    }
+
+    @Test
+    public void patientControllerGetAddPatientForm() throws Exception {
+
+        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders.get("/patient/add").accept(MediaType.APPLICATION_JSON_VALUE)).andReturn();
+
+        assertTrue(mvcResult.getResponse().getStatus() == 200);
+    }
+
+    @Test
+    public void patientControllerPostValidateAddsEntry() throws Exception {
+
+        MvcResult mvcResult = mockMvc.perform(
+                post("/patient/validate")
+                        .param("familyName", "testname")
+                        .param("givenName", "testname")
+                        .param("dob","2015-12-31T00:00:00.000Z")
+                        .param("sex", "M")
+                        .param("address", "testaddress")
+                        .param("phone", "111-222-3333")
+                        .accept(MediaType.ALL)).andReturn();
+
+        //Verify entry is added to DB and we are redirected (302)
+        assertTrue(mvcResult.getResponse().getStatus() == 302);
+        Mockito.verify(patientRepository, Mockito.times(1)).save(any(Patient.class));
+    }
+
+    @Test
+    public void bidListControllerPostValidateDoesNotAddBadEntry() throws Exception {
+
+        MvcResult mvcResult = mockMvc.perform(
+                post("/patient/validate")
+                        .param("familyName", "testname")
+                        .param("givenName", "testname")
+                        .param("dob","2015-12-31T00:00:00.000Z")
+                        .param("sex", "M")
+                        .param("address", "testaddress")
+                        .param("phone", "telephone")
+                        .accept(MediaType.ALL)).andReturn();
+
+        //Verify no entres are added to DB and we remain on add page (200)
+        assertTrue(mvcResult.getResponse().getStatus() == 200);
+        Mockito.verify(patientRepository, Mockito.times(0)).save(any(Patient.class));
+    }
+
+
+}


### PR DESCRIPTION
validate_service (View Patient Demographics)

- added MockMvc tests to test&validate all endpoints/services
-- PatientControllerUITests tests endpoints used for frontend
-- PatientControllerAPITests tests REST endpoints for direct API access
- updated docker-compose.yml & created application-test.properties to add test database
- Took this opportunity to add a separate API endpoint to allow Patients to be added via API call rather than UI

https://trello.com/c/v4voHBKp/1-view-patient-demographics