### PR TITLE
patient_demographics_docker (Patient Demographics Docker)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM eclipse-temurin:11
+RUN apt-get update
+RUN apt-get install -y maven
+COPY pom.xml /usr/local/service/pom.xml
+COPY src /usr/local/service/src
+WORKDIR /usr/local/service
+RUN mvn package -Dmaven.test.skip
+CMD ["java","-jar","target/mediscreen-0.1.0-SNAPSHOT.jar"]

--- a/docker-compose-test-db.yml
+++ b/docker-compose-test-db.yml
@@ -1,0 +1,24 @@
+version: '3.1'
+
+services:
+    patientdb-test:
+        image: mysql
+        command: --default-authentication-plugin=mysql_native_password
+        restart: always
+        environment:
+            MYSQL_ROOT_PASSWORD: 'password'
+            MYSQL_DATABASE: 'mediscreen-test'
+        healthcheck:
+            test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+            timeout: 20s
+            retries: 10
+        ports:
+            - "3315:3306"
+        expose:
+            - "3315"
+        volumes:
+            - mediscreen-db:/var/lib/mediscreen-test
+        container_name: patientdb-test
+volumes:
+    mediscreen-db:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,52 +1,41 @@
 version: '3.1'
 
 services:
-    patientsdb:
+    patientdb:
         image: mysql
         command: --default-authentication-plugin=mysql_native_password
         restart: always
         environment:
             MYSQL_ROOT_PASSWORD: 'password'
             MYSQL_DATABASE: 'mediscreen'
+        healthcheck:
+            test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+            timeout: 20s
+            retries: 10
         ports:
             - "3310:3306"
         expose:
             - "3310"
         volumes:
             - mediscreen-db:/var/lib/mediscreen
-        container_name: patients_db
+        container_name: patientdb
         networks:
             - system
-            - admin
-    patientsdb-test:
-        image: mysql
-        command: --default-authentication-plugin=mysql_native_password
-        restart: always
-        environment:
-            MYSQL_ROOT_PASSWORD: 'password'
-            MYSQL_DATABASE: 'mediscreen-test'
+    mediscreenapp:
+        build:
+            context: ./Mediscreen
+            dockerfile: Dockerfile
+        container_name: mediscreenapp
+        depends_on:
+            patientdb:
+                condition: service_healthy
         ports:
-            - "3311:3306"
-        expose:
-            - "3311"
-        volumes:
-            - mediscreen-db:/var/lib/mediscreen-test
-        container_name: patients_db-test
+            - "8080:8080"
         networks:
-            - system
-            - admin
-    adminer:
-        image: adminer
-        restart: always
-        ports: 
-            - "9000:8080"
-        expose:
-            - "9000"
-        networks:
-            - admin       
+            - system            
 volumes:
     mediscreen-db:
 
 networks:
     system:
-    admin:
+

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,11 @@
 	</parent>
 	<groupId>com.abernathy</groupId>
 	<artifactId>mediscreen</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.1.0-SNAPSHOT</version>
 	<name>mediscreen</name>
 	<description>Mediscreen App for Abernathy Clinic</description>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>11</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,7 +1,7 @@
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
-spring.datasource.url=jdbc:mysql://localhost:3311/mediscreen-test
+spring.datasource.url=jdbc:mysql://localhost:3315/mediscreen-test
 spring.datasource.username=root
 spring.datasource.password=password
 spring.datasource.initialization-mode=always

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,9 @@
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
-spring.datasource.url=jdbc:mysql://localhost:3310/mediscreen
+#alternative datasource url for testing in Intellij
+#spring.datasource.url=jdbc:mysql://localhost:3310/mediscreen
+spring.datasource.url=jdbc:mysql://patientdb:3306/mediscreen
 spring.datasource.username=root
 spring.datasource.password=password
 spring.datasource.initialization-mode=always

--- a/src/test/java/com/abernathy/mediscreen/MediscreenApplicationTests.java
+++ b/src/test/java/com/abernathy/mediscreen/MediscreenApplicationTests.java
@@ -2,8 +2,11 @@ package com.abernathy.mediscreen;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@TestPropertySource(
+		locations = "classpath:application-test.properties")
 class MediscreenApplicationTests {
 
 	@Test


### PR DESCRIPTION
- Added Dockerfile to build app and create Docker image
- Added docker-compose.yml to build network with mysql image
- Updated application.properties to connect to mysql docker
- Added application-test.properties to connect to a separate mysql for testing
- Added docker-compose-test-db.yml to allow creation of mysql database for running tests

Updates to allow app to be deployed as a Docker service alongside a mysql database docker.
Note Dockerfile is configured to build without running tests due to the requirement of a database; the separate docker-compose-test-db.yml is provided to allow creation of a test database for the app to use during testing.

https://trello.com/c/LT4oiXbB/5-patient-demographics-docker