### PR TITLE
updates_for_retrofit_calls (Generate Diabetes Assessment)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,11 @@
             <version>2.8.5</version>
             <scope>test</scope>
         </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+		</dependency>
+	</dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/abernathy/mediscreen/controllers/PatientController.java
+++ b/src/main/java/com/abernathy/mediscreen/controllers/PatientController.java
@@ -2,6 +2,8 @@ package com.abernathy.mediscreen.controllers;
 
 import com.abernathy.mediscreen.domain.Patient;
 import com.abernathy.mediscreen.service.PatientService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +22,8 @@ public class PatientController {
     PatientService patientService;
 
     private static final Logger logger = LogManager.getLogger("PatientController");
+
+    private Gson gson = new GsonBuilder().create();
 
     //Endpoints for serving front end
     @RequestMapping("/patient/list")
@@ -78,6 +82,15 @@ public class PatientController {
     public ResponseEntity<String> updatePatientApi(@Valid @RequestBody Patient patient, BindingResult result, Model model) {
         logger.info("User connected to /patient/add endpoint");
         return patientService.updateFromApi(patient, result, model);
+    }
+
+    //Endpoints for serving Retrofit calls
+
+    @GetMapping("/patient/api/retro/get/{id}")
+    @ResponseBody
+    public String getPatientRetro(@PathVariable("id") Integer id) {
+        logger.info("Service call made to /patient/api/retro/get/ endpoint with id " + id);
+        return gson.toJson(patientService.getFromRetro(id));
     }
 
 }

--- a/src/main/java/com/abernathy/mediscreen/service/BaseService.java
+++ b/src/main/java/com/abernathy/mediscreen/service/BaseService.java
@@ -188,4 +188,22 @@ public abstract class BaseService <E extends DomainElement> {
         return new ResponseEntity<String>(e.toString(), new HttpHeaders(), HttpStatus.OK);
     }
 
+    //Methods to serve RETROFIT API requests
+
+    /**
+     * Method to obtain DomainElement for get requests received via other application services
+     *
+     * @param id id parameter of element
+     * @return DomainElement
+     */
+    public E getFromRetro(Integer id) {
+        try {
+            E e = repository.findById(id).orElseThrow(() -> new IllegalArgumentException("Invalid " + getType() + " Id:" + id));
+            return e;
+        }
+        catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
 }

--- a/src/test/java/com/abernathy/mediscreen/api/PatientControllerUITests.java
+++ b/src/test/java/com/abernathy/mediscreen/api/PatientControllerUITests.java
@@ -151,24 +151,4 @@ public class PatientControllerUITests {
         Mockito.verify(patientRepository, Mockito.times(0)).save(any(Patient.class));
     }
 
-    @Test
-    public void patientControllerPostDoesNotUpdateWithInvalidID() throws Exception {
-
-        MvcResult mvcResult = mockMvc.perform(
-                post("/patient/update/1")
-                        .param("patientId", "1")
-                        .param("familyName", "testname")
-                        .param("givenName", "testname")
-                        .param("dob","2015-12-31T00:00:00.000Z")
-                        .param("sex", "M")
-                        .param("address", "testaddress")
-                        .param("phone", "1112223333")
-                        .accept(MediaType.ALL)).andReturn();
-
-        //Verify entry is not updated in DB and we remain on form (200)
-        assertTrue(mvcResult.getResponse().getStatus() == 200);
-        Mockito.verify(patientRepository, Mockito.times(0)).save(any(Patient.class));
-    }
-
-
 }


### PR DESCRIPTION
- Added endpoint for calls from other service apps
- Added method to BaseService to support this
- Added GSON to POM

Updates to allow app to be called from other microservices using Retrofit. New endpoint returns output as JSON string via GSON, without any response entity additions, to allow Retrofit to parse.

https://trello.com/c/cedtNn3j/7-generate-diabetes-assessment